### PR TITLE
Customizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea/
 
 *debug.log*
 *error.log*

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,6 +1,6 @@
 const shared = { webpack: false, running: false }
 
 module.exports = [
-  { path: "dist/vue-treeselect.umd.min.js", limit: "16.5 KB", ...shared },
+  { path: "dist/vue-treeselect.umd.min.js", limit: "16.6 KB", ...shared },
   { path: "dist/vue-treeselect.min.css", limit: "5 KB", ...shared },
 ]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # vue-treeselect
-[![npm](https://badgen.now.sh/npm/v/@riophae/vue-treeselect)](https://www.npmjs.com/package/@riophae/vue-treeselect) [![Build](https://badgen.now.sh/circleci/github/riophae/vue-treeselect)](https://circleci.com/gh/riophae/vue-treeselect/tree/master) [![Coverage](https://badgen.net/codecov/c/github/riophae/vue-treeselect)](https://codecov.io/gh/riophae/vue-treeselect?branch=master)
-![npm monthly downloads](https://badgen.now.sh/npm/dm/@riophae/vue-treeselect)
-![jsDelivr monthly hits](https://badgen.net/jsdelivr/hits/npm/@riophae/vue-treeselect) [![Known vulnerabilities](https://snyk.io/test/npm/@riophae/vue-treeselect/badge.svg)](https://snyk.io/test/npm/@riophae/vue-treeselect) ![License](https://badgen.net/github/license/riophae/vue-treeselect)
+[![npm](https://badgen.now.sh/npm/v/@nationaljournal/vue-treeselect)](https://www.npmjs.com/package/@nationaljournal/vue-treeselect) [![Build](https://badgen.now.sh/circleci/github/nationaljournal/vue-treeselect)](https://circleci.com/gh/nationaljournal/vue-treeselect/tree/master) [![Coverage](https://badgen.net/codecov/c/github/nationaljournal/vue-treeselect)](https://codecov.io/gh/nationaljournal/vue-treeselect?branch=master)
+![npm monthly downloads](https://badgen.now.sh/npm/dm/@nationaljournal/vue-treeselect)
+![jsDelivr monthly hits](https://badgen.net/jsdelivr/hits/npm/@nationaljournal/vue-treeselect) [![Known vulnerabilities](https://snyk.io/test/npm/@nationaljournal/vue-treeselect/badge.svg)](https://snyk.io/test/npm/@nationaljournal/vue-treeselect) ![License](https://badgen.net/github/license/nationaljournal/vue-treeselect)
 
 > A multi-select component with nested options support for Vue.js
 
-![Vue-Treeselect Screenshot](https://raw.githubusercontent.com/riophae/vue-treeselect/master/screenshot.png)
+![Vue-Treeselect Screenshot](https://raw.githubusercontent.com/nationaljournal/vue-treeselect/master/screenshot.png)
 
 ### Features
 
@@ -25,7 +25,7 @@
 It's recommended to install vue-treeselect via npm, and build your app using a bundler like [webpack](https://webpack.js.org/).
 
 ```bash
-npm install --save @riophae/vue-treeselect
+npm install --save @nationaljournal/vue-treeselect
 ```
 
 This example shows how to integrate vue-treeselect with your [Vue SFCs](https://vuejs.org/v2/guide/single-file-components.html).
@@ -40,9 +40,9 @@ This example shows how to integrate vue-treeselect with your [Vue SFCs](https://
 
 <script>
   // import the component
-  import Treeselect from '@riophae/vue-treeselect'
+  import Treeselect from '@nationaljournal/vue-treeselect'
   // import the styles
-  import '@riophae/vue-treeselect/dist/vue-treeselect.css'
+  import '@nationaljournal/vue-treeselect/dist/vue-treeselect.css'
 
   export default {
     // register the component
@@ -83,8 +83,8 @@ If you just don't want to use webpack or any other bundlers, you can simply incl
     <!-- include Vue 2.x -->
     <script src="https://cdn.jsdelivr.net/npm/vue@^2"></script>
     <!-- include vue-treeselect & its styles. you can change the version tag to better suit your needs. -->
-    <script src="https://cdn.jsdelivr.net/npm/@riophae/vue-treeselect@^0.4.0/dist/vue-treeselect.umd.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@riophae/vue-treeselect@^0.4.0/dist/vue-treeselect.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/@nationaljournal/vue-treeselect@^0.5.0/dist/vue-treeselect.umd.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@nationaljournal/vue-treeselect@^0.5.0/dist/vue-treeselect.min.css">
   </head>
   <body>
     <div id="app">
@@ -142,7 +142,7 @@ It should function well on IE9, but the style can be slightly broken due to the 
 
 ### Bugs
 
-You can use this [pen](https://codepen.io/riophae/pen/MExgzP) to reproduce bugs and then [open an issue](https://github.com/riophae/vue-treeselect/issues/new).
+You can use this [pen](https://codepen.io/riophae/pen/MExgzP) to reproduce bugs and then [open an issue](https://github.com/nationaljournal/vue-treeselect/issues/new).
 
 ### Contributing
 
@@ -167,6 +167,6 @@ Some icons used in this project:
 
 ### License
 
-Copyright (c) 2017-present [Riophae Lee](https://github.com/riophae).
+Copyright (c) 2020-present [National Journal](https://github.com/nationaljournal).
 
-Released under the [MIT License](https://github.com/riophae/vue-treeselect/blob/master/LICENSE).
+Released under the [MIT License](https://github.com/nationaljournal/vue-treeselect/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 ![Vue-Treeselect Screenshot](https://raw.githubusercontent.com/nationaljournal/vue-treeselect/master/screenshot.png)
 
+### Differences from `riophae/vue-treeselect`
+
+- Added `aria-label` prop to input.
+
 ### Features
 
 - Single & multiple select with nested options support

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Added `aria-label` prop to input.
 - Added `exclusive` prop to force one branch expanded at a time.
 - Added `showSelectedChildrenCount` prop to display count of selected items under a branch node
+- Automatically collapse branch node if it's selected.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 ### Differences from `riophae/vue-treeselect`
 
 - Added `aria-label` prop to input.
+- Added `exclusive` prop to force one branch expanded at a time.
+- Added `showSelectedChildrenCount` prop to display count of selected items under a branch node
 
 ### Features
 

--- a/build/webpack-configs/base.js
+++ b/build/webpack-configs/base.js
@@ -13,7 +13,7 @@ module.exports = {
       // see: https://vuejs.org/v2/guide/installation.html#Explanation-of-Different-Builds
       'vue$': 'vue/dist/vue',
       // for consistent docs
-      '@riophae/vue-treeselect': utils.resolve('src'),
+      '@nationaljournal/vue-treeselect': utils.resolve('src'),
       // for shorter import path in tests
       '@src': utils.resolve('src'),
     },

--- a/docs/components/AsyncSearching.vue
+++ b/docs/components/AsyncSearching.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-  import { ASYNC_SEARCH } from '@riophae/vue-treeselect'
+  import { ASYNC_SEARCH } from '@nationaljournal/vue-treeselect'
 
   const simulateAsyncOperation = fn => {
     setTimeout(fn, 2000)

--- a/docs/components/DelayedLoading.vue
+++ b/docs/components/DelayedLoading.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-  import { LOAD_CHILDREN_OPTIONS } from '@riophae/vue-treeselect'
+  import { LOAD_CHILDREN_OPTIONS } from '@nationaljournal/vue-treeselect'
 
   // We just use `setTimeout()` here to simulate an async operation
   // instead of requesting a real API server for demo purpose.

--- a/docs/components/DelayedRootOptions.vue
+++ b/docs/components/DelayedRootOptions.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-  import { LOAD_ROOT_OPTIONS } from '@riophae/vue-treeselect'
+  import { LOAD_ROOT_OPTIONS } from '@nationaljournal/vue-treeselect'
 
   const sleep = d => new Promise(r => setTimeout(r, d))
   let called = false

--- a/docs/components/DocProps.vue
+++ b/docs/components/DocProps.vue
@@ -316,7 +316,7 @@
         name: 'showCountOf',
         type: 'String',
         defaultValue: code('"ALL_CHILDREN"'),
-        description: `Used in conjunction with ${code('showCount')} to specify which type of count number should be displayed. <br>Acceptable values: ${code('"ALL_CHILDREN"')}, ${code('"ALL_DESCENDANTS"')}, ${code('"LEAF_CHILDREN"')} or ${code('"LEAF_DESCENDANTS"')}.`,
+        description: `Used in conjunction with ${code('showCount')} to specify which type of count number should be displayed. <br>Acceptable values: ${code('"ALL_CHILDREN"')}, ${code('"ALL_CHILDREN_SELECTED"')}, ${code('"ALL_DESCENDANTS"')}, ${code('"LEAF_CHILDREN"')} or ${code('"LEAF_DESCENDANTS"')}.`,
       }, {
         name: 'showCountOnSearch',
         type: 'Boolean',

--- a/docs/components/MoreFeatures.vue
+++ b/docs/components/MoreFeatures.vue
@@ -9,6 +9,9 @@
         :disabled="disabled"
         :open-on-click="openOnClick"
         :open-on-focus="openOnFocus"
+        :exclusive="exclusive"
+        :show-count="showCount"
+        :show-selected-children-count="showSelectedChildrenCount"
         :clear-on-select="clearOnSelect"
         :close-on-select="closeOnSelect"
         :always-open="alwaysOpen"
@@ -16,6 +19,7 @@
         :options="options"
         :limit="3"
         :max-height="200"
+        :value-consists-of="valueConsistsOf"
         v-model="value"
         />
     </div>
@@ -29,6 +33,11 @@
     <p>
       <label><input type="checkbox" v-model="openOnClick">Open on click</label>
       <label><input type="checkbox" v-model="openOnFocus">Open on focus</label>
+      <label><input type="checkbox" v-model="exclusive">Exclusive</label>
+    </p>
+    <p>
+      <label><input type="checkbox" v-model="showCount">Show children count</label>
+      <label><input type="checkbox" v-model="showSelectedChildrenCount">Show selected children count</label>
     </p>
     <p>
       <label><input type="checkbox" v-model="clearOnSelect">Clear on select</label>
@@ -38,6 +47,10 @@
       <label><input type="checkbox" v-model="alwaysOpen">Always open</label>
       <label><input type="checkbox" v-model="appendToBody">Append to body</label>
       <label><input type="checkbox" v-model="rtl">RTL mode</label>
+    </p>
+    <p><strong>Value consists of:</strong></p>
+    <p class="options">
+      <label><input type="radio" value="ALL" v-model="valueConsistsOf">All</label><br>
     </p>
   </div>
 </template>
@@ -53,12 +66,16 @@
       disabled: false,
       openOnClick: true,
       openOnFocus: false,
+      exclusive: false,
+      showCount: false,
+      showSelectedChildrenCount: false,
       clearOnSelect: true,
       closeOnSelect: false,
       alwaysOpen: false,
       appendToBody: false,
+      valueConsistsOf: 'ALL',
       rtl: false,
-      value: [ 'a' ],
+      value: [],
       options: generateOptions(2, 3),
     }),
 

--- a/docs/index.pug
+++ b/docs/index.pug
@@ -51,10 +51,10 @@ html(lang="en")
               | Vue
               span.site-header-logo-component-name Treeselect
           nav.site-header-nav
-            a.site-header-nav-item(href="https://github.com/riophae/vue-treeselect/releases")
+            a.site-header-nav-item(href="https://github.com/nationaljournal/vue-treeselect/releases")
               =`v${require('../package.json').version}`
             span.site-header-nav-item
-              a.github-button(href="https://github.com/riophae/vue-treeselect" data-show-count="true" aria-label="Star riophae/vue-treeselect on GitHub")
+              a.github-button(href="https://github.com/nationaljournal/vue-treeselect" data-show-count="true" aria-label="Star nationaljournal/vue-treeselect on GitHub")
                 | Star
       div.container
         section#main
@@ -68,7 +68,7 @@ html(lang="en")
             include ./partials/api
       footer.site-footer
         div.container
-          | Copyright &copy; 2017-#{new Date().getFullYear()} <a href="https://github.com/riophae">Riophae Lee</a>. MIT Licensed.
+          | Copyright &copy; 2020-#{new Date().getFullYear()} <a href="https://github.com/nationaljournal">National Journal</a>. MIT Licensed.
     script(src="https://buttons.github.io/buttons.js" async defer)
 
 +renderToc()

--- a/docs/partials/getting-started.pug
+++ b/docs/partials/getting-started.pug
@@ -5,7 +5,7 @@ section
     It's recommended to install vue-treeselect via npm, and build your app using a bundler like [webpack](https://webpack.js.org/).
 
     ```bash
-    npm install --save @riophae/vue-treeselect
+    npm install --save @nationaljournal/vue-treeselect
     ```
 
   :markdown-it
@@ -21,9 +21,9 @@ section
 
     <script>
       // import the component
-      import Treeselect from '@riophae/vue-treeselect'
+      import TreeSelect from '@nationaljournal/vue-treeselect'
       // import the styles
-      import '@riophae/vue-treeselect/dist/vue-treeselect.css'
+      import '@nationaljournal/vue-treeselect/dist/vue-treeselect.css'
 
       export default {
         // register the component
@@ -64,8 +64,8 @@ section
         <!-- include Vue 2.x -->
         <script src="https://cdn.jsdelivr.net/npm/vue@^2"></script>
         <!-- include vue-treeselect & its styles. you can change the version tag to better suit your needs. -->
-        <script src="https://cdn.jsdelivr.net/npm/@riophae/vue-treeselect@^0.4.0/dist/vue-treeselect.umd.min.js"></script>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@riophae/vue-treeselect@^0.4.0/dist/vue-treeselect.min.css">
+        <script src="https://cdn.jsdelivr.net/npm/@nationaljournal/vue-treeselect@^0.5.0/dist/vue-treeselect.umd.min.js"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@nationaljournal/vue-treeselect@^0.5.0/dist/vue-treeselect.min.css">
       </head>
       <body>
         <div id="app">

--- a/docs/partials/introduction.pug
+++ b/docs/partials/introduction.pug
@@ -2,7 +2,7 @@
 
 section
   :markdown-it(html=true)
-    [vue-treeselect](https://github.com/riophae/vue-treeselect) is a multi-select component with nested options support for [Vue.js](https://www.vuejs.org).
+    [vue-treeselect](https://github.com/nationaljournal/vue-treeselect) is a multi-select component with nested options support for [Vue.js](https://www.vuejs.org).
 
     - Single & multiple select with nested options support
     - Fuzzy matching
@@ -10,6 +10,6 @@ section
     - Delayed loading (load data of deep level options only when needed)
     - Keyboard support (navigate using <kbd>Arrow Up</kbd> & <kbd>Arrow Down</kbd> keys, select option using <kbd>Enter</kbd> key, etc.)
     - Rich options & highly customizable
-    - Supports [a wide range of browsers](https://github.com/riophae/vue-treeselect#browser-compatibility)
+    - Supports [a wide range of browsers](https://github.com/nationaljournal/vue-treeselect#browser-compatibility)
 
     *Requires Vue 2.2+*

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "verify-builds": "size-limit && node build/verify-builds.js",
     "postinstall": "cd ./node_modules/@nationaljournal/vue-treeselect && npm install && npm run finish",
-    "finish": "npm test && npm run build-library && npm run verify-builds"
+    "finish": "npm run lint && npm test && npm run build-library && npm run verify-builds"
   },
   "pre-commit": "lint",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "preview-docs": "http-server gh-pages",
     "gh-pages": "npm run build-docs && gh-pages --dist gh-pages --branch gh-pages --dotfiles",
     "cleanup-cov": "rimraf test/unit/coverage",
-    "unit": "npm run cleanup-cov && karma start test/unit/karma.conf.js --watch",
+    "unit": "npm run cleanup-cov && karma start test/unit/karma.config.js --watch",
     "testonly": "npm run cleanup-cov && karma start test/unit/karma.config.js --single-run",
     "test": "npm run testonly",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "@riophae/vue-treeselect",
-  "version": "0.4.0",
+  "name": "@nationaljournal/vue-treeselect",
+  "version": "0.5.0",
   "description": "A multi-select component with nested options support for Vue.js",
-  "author": "Riophae Lee <riophaelee@gmail.com>",
+  "author": "Hasan Tuncay <htuncay@nationaljournal.com>",
   "license": "MIT",
-  "homepage": "https://vue-treeselect.js.org/",
-  "repository": "riophae/vue-treeselect",
+  "homepage": "https://github.com/NationalJournal/vue-treeselect",
+  "bugs": {
+    "url": "https://github.com/NationalJournal/vue-treeselect/issues"
+  },
+  "repository": "nationaljournal/vue-treeselect",
   "main": "dist/vue-treeselect.cjs.js",
   "unpkg": "dist/vue-treeselect.umd.min.js",
   "css": "dist/vue-treeselect.min.css",
@@ -28,6 +31,7 @@
     "lint:css": "stylelint '**/*.less'",
     "lint": "npm run lint:js && npm run lint:css",
     "verify-builds": "size-limit && node build/verify-builds.js",
+    "postinstall": "cd ./node_modules/@nationaljournal/vue-treeselect && npm install && npm run finish",
     "finish": "npm test && npm run build-library && npm run verify-builds"
   },
   "pre-commit": "lint",

--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -254,6 +254,7 @@
           <input ref="input"
             class="vue-treeselect__input"
             type="text"
+            aria-label={instance.ariaLabel}
             autocomplete="off"
             tabIndex={instance.tabIndex}
             required={instance.required && !instance.hasValue}

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -158,17 +158,17 @@
 
       renderLabel() {
         const { instance, node } = this
-        const shouldShowCount = (
-          node.isBranch && (instance.localSearch.active
-            ? instance.showCountOnSearchComputed
-            : instance.showCount
-          )
-        )
+        const isSearchActive = instance.localSearch.active
+        const isBranch = node.isBranch
+        const shouldShowCount = isBranch && (isSearchActive ? instance.showCountOnSearchComputed : instance.showCount)
         const count = shouldShowCount
-          ? instance.localSearch.active
+          ? (instance.localSearch.active
             ? instance.localSearch.countMap[node.id][instance.showCountOf]
-            : node.count[instance.showCountOf]
+            : node.count[instance.showCountOf])
           : NaN
+        const shouldShowSelectedCount = isBranch && !isSearchActive && instance.showSelectedChildrenCount
+        const totalCount = node.count != null ? node.count.ALL_CHILDREN : '-'
+        const selectedCount = node.count != null ? node.count.ALL_CHILDREN_SELECTED : '-'
         const labelClassName = 'vue-treeselect__label'
         const countClassName = 'vue-treeselect__count'
         const customLabelRenderer = instance.$scopedSlots['option-label']
@@ -184,8 +184,11 @@
         return (
           <label class={labelClassName}>
             {node.label}
-            {shouldShowCount && (
-              <span class={countClassName}>({count})</span>
+            {((shouldShowCount && !shouldShowSelectedCount) || (shouldShowSelectedCount && selectedCount === 0)) && (
+              <span class={countClassName}>({!isNaN(count) ? count : totalCount}{isSearchActive ? ' found' : ''})</span>
+            )}
+            {shouldShowSelectedCount && selectedCount !== 0 && (
+              <span class={countClassName}> ({selectedCount}/{totalCount} selected)</span>
             )}
           </label>
         )

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,6 +8,7 @@ export const CHECKED = 2
 
 // Types of count number.
 export const ALL_CHILDREN = 'ALL_CHILDREN'
+export const ALL_CHILDREN_SELECTED = 'ALL_CHILDREN_SELECTED'
 export const ALL_DESCENDANTS = 'ALL_DESCENDANTS'
 export const LEAF_CHILDREN = 'LEAF_CHILDREN'
 export const LEAF_DESCENDANTS = 'LEAF_DESCENDANTS'

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -104,6 +104,14 @@ export default {
     },
 
     /**
+     * Set the value for aria-label.
+     */
+    ariaLabel: {
+      type: String,
+      default: 'tree-select',
+    },
+
+    /**
      * Whether to enable async search mode.
      */
     async: {

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -1887,13 +1887,17 @@ export default {
             this.addValue(descendant)
           }
         })
+
+        node.isExpanded = false
       }
 
       if (isFullyChecked) {
         let curr = node
         while ((curr = curr.parentNode) !== NO_PARENT_NODE) {
-          if (curr.children.every(this.isSelected)) this.addValue(curr)
-          else break
+          if (curr.children.every(this.isSelected)) {
+            curr.isExpanded = false
+            this.addValue(curr)
+          } else break
         }
       }
     },

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -15,6 +15,7 @@ import {
   ALL, BRANCH_PRIORITY, LEAF_PRIORITY, ALL_WITH_INDETERMINATE,
   ALL_CHILDREN, ALL_DESCENDANTS, LEAF_CHILDREN, LEAF_DESCENDANTS,
   ORDER_SELECTED, LEVEL, INDEX,
+  ALL_CHILDREN_SELECTED,
 } from '../constants'
 
 function sortValueByIndex(a, b) {
@@ -276,6 +277,14 @@ export default {
     delimiter: {
       type: String,
       default: ',',
+    },
+
+    /**
+     * Only expand one branch at a time.
+     */
+    exclusive: {
+      type: Boolean,
+      default: false,
     },
 
     /**
@@ -544,6 +553,7 @@ export default {
 
     /**
      * Whether to show a children count next to the label of each branch node.
+     * @type {Boolean}
      */
     showCount: {
       type: Boolean,
@@ -554,6 +564,7 @@ export default {
      * Used in conjunction with `showCount` to specify which type of count number should be displayed.
      * Acceptable values:
      *   - "ALL_CHILDREN"
+     *   - "ALL_CHILDREN_SELECTED"
      *   - "ALL_DESCENDANTS"
      *   - "LEAF_CHILDREN"
      *   - "LEAF_DESCENDANTS"
@@ -562,7 +573,7 @@ export default {
       type: String,
       default: ALL_CHILDREN,
       validator(value) {
-        const acceptableValues = [ ALL_CHILDREN, ALL_DESCENDANTS, LEAF_CHILDREN, LEAF_DESCENDANTS ]
+        const acceptableValues = [ ALL_CHILDREN, ALL_CHILDREN_SELECTED, ALL_DESCENDANTS, LEAF_CHILDREN, LEAF_DESCENDANTS ]
         return includes(acceptableValues, value)
       },
     },
@@ -573,6 +584,14 @@ export default {
      * @type {boolean}
      */
     showCountOnSearch: null,
+
+    /**
+     * Whether to show selected children count (if any exists) next to the label of each branch node.
+     */
+    showSelectedChildrenCount: {
+      type: Boolean,
+      default: false,
+    },
 
     /**
      * In which order the selected options should be displayed in trigger & sorted in `value` array.
@@ -937,7 +956,7 @@ export default {
         const prevNodeMap = this.forest.nodeMap
         this.forest.nodeMap = createMap()
         this.keepDataOfSelectedNodes(prevNodeMap)
-        this.forest.normalizedOptions = this.normalize(NO_PARENT_NODE, options, prevNodeMap)
+        this.forest.normalizedOptions = this.normalize(NO_PARENT_NODE, options, prevNodeMap, this.forest.selectedNodeIds)
         // Cases that need fixing `selectedNodeIds`:
         //   1) Children options of a checked node have been delayed loaded,
         //      we should also mark these children as checked. (multi-select mode)
@@ -1223,6 +1242,7 @@ export default {
           node.hasMatchedDescendants = false
           this.$set(this.localSearch.countMap, node.id, {
             [ALL_CHILDREN]: 0,
+            [ALL_CHILDREN_SELECTED]: 0,
             [ALL_DESCENDANTS]: 0,
             [LEAF_CHILDREN]: 0,
             [LEAF_DESCENDANTS]: 0,
@@ -1473,6 +1493,17 @@ export default {
     },
 
     toggleExpanded(node) {
+      if (this.exclusive && node.isExpanded === false) {
+        Object.keys(this.forest.nodeMap).forEach(key => {
+          this.forest.nodeMap[key].isExpanded = false
+        })
+        node.isExpanded = true
+        if (!node.childrenStates.isLoaded) {
+          this.loadChildrenOptions(node)
+        }
+        return
+      }
+
       let nextState
 
       if (this.localSearch.active) {
@@ -1498,6 +1529,9 @@ export default {
       if (this.multiple) {
         this.traverseAllNodesByIndex(node => {
           checkedStateMap[node.id] = UNCHECKED
+          if (node.count != null) {
+            node.count.ALL_CHILDREN_SELECTED = 0
+          }
         })
 
         this.selectedNodes.forEach(selectedNode => {
@@ -1505,6 +1539,7 @@ export default {
 
           if (!this.flat && !this.disableBranchNodes) {
             selectedNode.ancestors.forEach(ancestorNode => {
+              ancestorNode.count.ALL_CHILDREN_SELECTED++
               if (!this.isSelected(ancestorNode)) {
                 checkedStateMap[ancestorNode.id] = INDETERMINATE
               }
@@ -1522,8 +1557,8 @@ export default {
       }
     },
 
-    normalize(parentNode, nodes, prevNodeMap) {
-      let normalizedOptions = nodes
+    normalize(parentNode, options, prevNodeMap, selectedNodeIds) {
+      let normalizedOptions = options
         .map(node => [ this.enhancedNormalizer(node), node ])
         .map(([ node, raw ], index) => {
           this.checkDuplication(node)
@@ -1535,6 +1570,7 @@ export default {
           const isBranch = Array.isArray(children) || children === null
           const isLeaf = !isBranch
           const isDisabled = !!node.isDisabled || (!this.flat && !isRootNode && parentNode.isDisabled)
+          const isSelected = selectedNodeIds != null && selectedNodeIds.filter(selectedId => (selectedId === id)).length > 0
           const isNew = !!node.isNew
           const lowerCased = this.matchKeys.reduce((prev, key) => ({
             ...prev,
@@ -1560,6 +1596,7 @@ export default {
           this.$set(normalized, 'isBranch', isBranch)
           this.$set(normalized, 'isLeaf', isLeaf)
           this.$set(normalized, 'isRootNode', isRootNode)
+          this.$set(normalized, 'isSelected', isSelected)
           this.$set(normalized, 'raw', raw)
 
           if (isBranch) {
@@ -1578,12 +1615,13 @@ export default {
             this.$set(normalized, 'showAllChildrenOnSearch', false)
             this.$set(normalized, 'count', {
               [ALL_CHILDREN]: 0,
+              [ALL_CHILDREN_SELECTED]: 0,
               [ALL_DESCENDANTS]: 0,
               [LEAF_CHILDREN]: 0,
               [LEAF_DESCENDANTS]: 0,
             })
             this.$set(normalized, 'children', isLoaded
-              ? this.normalize(normalized, children, prevNodeMap)
+              ? this.normalize(normalized, children, prevNodeMap, selectedNodeIds)
               : [])
 
             if (isDefaultExpanded === true) normalized.ancestors.forEach(ancestor => {

--- a/test/unit/specs/Basic.spec.js
+++ b/test/unit/specs/Basic.spec.js
@@ -50,6 +50,7 @@ describe('Basic', () => {
         isMatched: jasmine.any(Boolean),
         isHighlighted: jasmine.any(Boolean),
         isDisabled: jasmine.any(Boolean),
+        isSelected: jasmine.any(Boolean),
         isNew: jasmine.any(Boolean),
         parentNode: jasmine.any(Object),
         ancestors: jasmine.any(Array),
@@ -73,6 +74,7 @@ describe('Basic', () => {
         children: jasmine.any(Array),
         count: {
           ALL_CHILDREN: jasmine.any(Number),
+          ALL_CHILDREN_SELECTED: jasmine.any(Number),
           ALL_DESCENDANTS: jasmine.any(Number),
           LEAF_CHILDREN: jasmine.any(Number),
           LEAF_DESCENDANTS: jasmine.any(Number),
@@ -463,6 +465,7 @@ describe('Basic', () => {
 
       expect(a.count).toEqual({
         ALL_CHILDREN: 2,
+        ALL_CHILDREN_SELECTED: 0,
         ALL_DESCENDANTS: 4,
         LEAF_CHILDREN: 1,
         LEAF_DESCENDANTS: 3,
@@ -472,6 +475,7 @@ describe('Basic', () => {
 
       expect(aa.count).toEqual({
         ALL_CHILDREN: 2,
+        ALL_CHILDREN_SELECTED: 0,
         ALL_DESCENDANTS: 2,
         LEAF_CHILDREN: 2,
         LEAF_DESCENDANTS: 2,
@@ -729,7 +733,7 @@ describe('Basic', () => {
     expect(vm.forest.nodeMap.a).not.toHaveMember('isFallbackNode')
   })
 
-  it('should rebuild state after swithching from single to multiple', () => {
+  it('should rebuild state after switching from single to multiple', () => {
     const wrapper = mount(Treeselect, {
       propsData: {
         options: [ {

--- a/test/unit/specs/Props.spec.js
+++ b/test/unit/specs/Props.spec.js
@@ -1195,11 +1195,16 @@ describe('Props', () => {
       })
 
       it('click on label of a branch node should not toggle expanding state when multiple=true', async () => {
-        wrapper.setProps({ multiple: true })
+        await setProps(wrapper, { multiple: true })
 
+        expect(vm.isSelected(vm.forest.nodeMap.branch)).toBe(false)
         expect(vm.forest.nodeMap.branch.isExpanded).toBe(true)
         await clickOnLabelOfBranchNode()
-        expect(vm.forest.nodeMap.branch.isExpanded).toBe(true)
+        expect(vm.isSelected(vm.forest.nodeMap.branch)).toBe(true)
+        expect(vm.forest.nodeMap.branch.isExpanded).toBe(false)
+        await clickOnLabelOfBranchNode()
+        expect(vm.isSelected(vm.forest.nodeMap.branch)).toBe(false)
+        expect(vm.forest.nodeMap.branch.isExpanded).toBe(false)
       })
 
       it('click on label of a branch node should close the dropdown when multiple=false & closeOnSelect=true', async () => {

--- a/test/unit/specs/Props.spec.js
+++ b/test/unit/specs/Props.spec.js
@@ -11,6 +11,8 @@ import {
   findMenuContainer,
   findOptionByNodeId,
   findLabelContainerByNodeId,
+  openMenu,
+  setProps,
 } from './shared'
 import Treeselect from '@src/components/Treeselect'
 import Option from '@src/components/Option'
@@ -319,12 +321,10 @@ describe('Props', () => {
           options: [],
         },
       })
-      const { vm } = wrapper
 
-      vm.openMenu()
-      await vm.$nextTick()
+      await openMenu(wrapper.vm)
 
-      const portalTarget = findPortalTarget(vm)
+      const portalTarget = findPortalTarget(wrapper.vm)
       expect(portalTarget.classList).toContain('vue-treeselect')
       expect(portalTarget.firstElementChild.classList).toContain('vue-treeselect__menu-container')
     })
@@ -340,8 +340,7 @@ describe('Props', () => {
       })
       const { vm } = wrapper
 
-      vm.openMenu()
-      await vm.$nextTick()
+      await openMenu(vm)
 
       expect(findPortalTarget(vm)).toBeTruthy()
 
@@ -388,8 +387,7 @@ describe('Props', () => {
       })
       const { vm } = wrapper
 
-      vm.openMenu()
-      await vm.$nextTick()
+      await openMenu(vm)
 
       const portalTarget = findPortalTarget(vm)
       const label = $('.vue-treeselect__label', portalTarget)
@@ -412,10 +410,8 @@ describe('Props', () => {
         },
         attachToDocument: true,
       })
-      const { vm } = wrapper
 
-      vm.openMenu()
-      await vm.$nextTick()
+      await openMenu(wrapper.vm)
 
       const menuContainer = findMenuContainer(wrapper)
       expect(menuContainer.element.style.zIndex).toBe('1')
@@ -431,12 +427,10 @@ describe('Props', () => {
         },
         attachToDocument: true,
       })
-      const { vm } = wrapper
 
-      vm.openMenu()
-      await vm.$nextTick()
+      await openMenu(wrapper.vm)
 
-      const portalTarget = findPortalTarget(vm)
+      const portalTarget = findPortalTarget(wrapper.vm)
       expect(portalTarget.style.zIndex).toBe('1')
 
       const $menuContainer = $('.vue-treeselect__menu-container', portalTarget)
@@ -966,8 +960,7 @@ describe('Props', () => {
       })
       const { vm } = wrapper
 
-      vm.openMenu()
-      await vm.$nextTick()
+      await openMenu(vm)
 
       const labelContainer = findLabelContainerByNodeId(wrapper, 'a')
 
@@ -988,8 +981,7 @@ describe('Props', () => {
       })
       const { vm } = wrapper
 
-      vm.openMenu()
-      await vm.$nextTick()
+      await openMenu(vm)
 
       const labelContainer = findLabelContainerByNodeId(wrapper, 'a')
 
@@ -1154,22 +1146,20 @@ describe('Props', () => {
       vm = wrapper.vm
     })
 
-    const getLabelContainerOfBranchNode = async () => {
-      vm.openMenu() // ensure the menu is opened otherwise the options won't be displayed
-      await vm.$nextTick()
+    const getLabelContainerOfBranchNode = async (nodeId = 'branch') => {
+      await openMenu(vm) // ensure the menu is opened otherwise the options won't be displayed
 
-      return findLabelContainerByNodeId(wrapper, 'branch')
+      return findLabelContainerByNodeId(wrapper, nodeId)
     }
 
-    const getLabelContainerOfLeafNode = async () => {
-      vm.openMenu() // ensure the menu is opened otherwise the options won't be displayed
-      await vm.$nextTick()
+    const getLabelContainerOfLeafNode = async (nodeId = 'leaf') => {
+      await openMenu(vm) // ensure the menu is opened otherwise the options won't be displayed
 
-      return findLabelContainerByNodeId(wrapper, 'leaf')
+      return findLabelContainerByNodeId(wrapper, nodeId)
     }
 
-    const clickOnLabelOfBranchNode = async () => {
-      const labelContainerOfBranchNode = await getLabelContainerOfBranchNode()
+    const clickOnLabelOfBranchNode = async (nodeId = 'branch') => {
+      const labelContainerOfBranchNode = await getLabelContainerOfBranchNode(nodeId)
       leftClick(labelContainerOfBranchNode)
     }
 
@@ -1214,8 +1204,7 @@ describe('Props', () => {
 
       it('click on label of a branch node should close the dropdown when multiple=false & closeOnSelect=true', async () => {
         wrapper.setProps({ multiple: false, closeOnSelect: true })
-        vm.openMenu()
-        await vm.$nextTick()
+        await openMenu(vm)
 
         expect(vm.menu.isOpen).toBe(true)
         await clickOnLabelOfBranchNode()
@@ -1262,8 +1251,7 @@ describe('Props', () => {
 
       it('click on label of a branch node should not close the dropdown when multiple=false & closeOnSelect=true', async () => {
         wrapper.setProps({ multiple: false, closeOnSelect: true })
-        vm.openMenu()
-        await vm.$nextTick()
+        await openMenu(vm)
 
         expect(vm.menu.isOpen).toBe(true)
         await clickOnLabelOfBranchNode()
@@ -1301,6 +1289,91 @@ describe('Props', () => {
             expect(vm.internalValue).toEqual([ 'leaf' ])
           })
         })
+      })
+    })
+  })
+
+  describe('exclusive', () => {
+    let wrapper, vm
+
+    beforeEach(() => {
+      wrapper = mount(Treeselect, {
+        sync: false,
+        propsData: {
+          flat: false,
+          options: [ {
+            id: 'branch1',
+            label: 'branch1',
+            isDefaultExpanded: true,
+            children: [ {
+              id: 'leaf1',
+              label: 'leaf1',
+            } ],
+          }, {
+            id: 'branch2',
+            label: 'branch2',
+            isDefaultExpanded: false,
+            children: [ {
+              id: 'leaf2',
+              label: 'leaf2',
+            } ],
+          } ],
+        },
+      })
+      vm = wrapper.vm
+    })
+
+    const getOptionArrowContainerByNodeId = async nodeId => {
+      await openMenu(vm) // ensure the menu is opened otherwise the options won't be displayed
+
+      return findOptionByNodeId(wrapper, nodeId).find('.vue-treeselect__option-arrow-container')
+    }
+
+    const clickOnArrowOfBranchNode = async nodeId => {
+      const labelContainerOfBranchNode = await getOptionArrowContainerByNodeId(nodeId)
+      leftClick(labelContainerOfBranchNode)
+    }
+
+    describe('when exclusive=true', () => {
+      it('should collapse other expanded branches when label is clicked', async () => {
+        await setProps(wrapper, { exclusive: true })
+
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(true)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(false)
+        await clickOnArrowOfBranchNode('branch2')
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(false)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(true)
+        await clickOnArrowOfBranchNode('branch1')
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(true)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(false)
+      })
+    })
+
+    describe('when exclusive=false', () => {
+      it('should NOT collapse other expanded branches when label is clicked', async () => {
+        await setProps(wrapper, { exclusive: false })
+
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(true)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(false)
+        await clickOnArrowOfBranchNode('branch2')
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(true)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(true)
+        await clickOnArrowOfBranchNode('branch1')
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(false)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(true)
+      })
+    })
+
+    describe('when exclusive is not specified', () => {
+      it('should NOT collapse other expanded branches when label is clicked', async () => {
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(true)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(false)
+        await clickOnArrowOfBranchNode('branch2')
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(true)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(true)
+        await clickOnArrowOfBranchNode('branch1')
+        expect(vm.forest.nodeMap.branch1.isExpanded).toBe(false)
+        expect(vm.forest.nodeMap.branch2.isExpanded).toBe(true)
       })
     })
   })
@@ -1343,8 +1416,7 @@ describe('Props', () => {
         })
         const { vm } = wrapper
 
-        vm.openMenu()
-        await vm.$nextTick()
+        await openMenu(vm)
 
         expect(wrapper.vm.menu.isOpen).toBe(true)
 
@@ -1384,17 +1456,17 @@ describe('Props', () => {
         expect(vm.trigger.isFocused).toBe(false)
       })
 
-      it('should be uanble to open the menu', () => {
+      it('should be uanble to open the menu', async () => {
         const wrapper = mount(Treeselect, {
           propsData: {
             options: [],
             disabled: true,
           },
         })
-        const { vm } = wrapper
 
-        wrapper.vm.openMenu()
-        expect(vm.menu.isOpen).toBe(false)
+        await openMenu(wrapper.vm)
+
+        expect(wrapper.vm.menu.isOpen).toBe(false)
       })
     })
   })
@@ -1798,14 +1870,14 @@ describe('Props', () => {
   })
 
   describe('options', () => {
-    it('show tip when `options` is an empty array', () => {
+    it('show tip when `options` is an empty array', async () => {
       const wrapper = mount(Treeselect, {
         propsData: {
           options: [],
         },
       })
 
-      wrapper.vm.openMenu()
+      await openMenu(wrapper.vm)
 
       const menu = wrapper.find('.vue-treeselect__menu')
       const noOptionsTip = menu.find('.vue-treeselect__no-options-tip')
@@ -2103,8 +2175,55 @@ describe('Props', () => {
     })
   })
 
-  it('showCount', () => {
-    // TODO
+  describe('showCount', () => {
+    let wrapper
+
+    beforeEach(async () => {
+      wrapper = mount(Treeselect, {
+        propsData: {
+          alwaysOpen: true,
+          options: [ {
+            id: 'a',
+            label: 'a',
+            children: [ {
+              id: 'aa',
+              label: 'aa',
+            }, {
+              id: 'ab',
+              label: 'ab',
+            } ],
+          }, {
+            id: 'b',
+            label: 'b',
+            children: [ {
+              id: 'ba',
+              label: 'ba',
+            } ],
+          } ],
+        },
+      })
+
+      await wrapper.vm.$nextTick()
+    })
+
+    it('when showCount=false', async () => {
+      await setProps(wrapper, { showCount: false })
+
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').exists()).toBeFalse()
+    })
+
+    it('when showCount not specified', () => {
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').exists()).toBeFalse()
+    })
+
+    it('when showCount=true', async () => {
+      await setProps(wrapper, { showCount: true })
+
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(2)')
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(1)')
+    })
   })
 
   describe('showCountOnSearch', () => {
@@ -2162,15 +2281,113 @@ describe('Props', () => {
     })
 
     it('should refresh count number after search changes', async () => {
-      wrapper.setProps({ showCountOnSearch: true })
+      await setProps(wrapper, { showCountOnSearch: true })
 
       await typeSearchText(wrapper, 'a')
-      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(2)')
-      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(1)')
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(2 found)')
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(1 found)')
 
       await typeSearchText(wrapper, 'b')
-      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(1)')
-      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(2)')
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(1 found)')
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(2 found)')
+    })
+  })
+
+  describe('showSelectedChildrenCount', () => {
+    let wrapper
+
+    beforeEach(async () => {
+      wrapper = mount(Treeselect, {
+        propsData: {
+          alwaysOpen: true,
+          multiple: true,
+          valueConsistsOf: 'ALL',
+          options: [ {
+            id: 'a',
+            label: 'a',
+            children: [ {
+              id: 'aa',
+              label: 'aa',
+            }, {
+              id: 'ab',
+              label: 'ab',
+            } ],
+          }, {
+            id: 'b',
+            label: 'b',
+            children: [ {
+              id: 'ba',
+              label: 'ba',
+            }, {
+              id: 'bb',
+              label: 'bb',
+            } ],
+          }, {
+            id: 'c',
+            label: 'c',
+            children: [ {
+              id: 'ca',
+              label: 'ca',
+            }, {
+              id: 'cb',
+              label: 'cb',
+            } ],
+          } ],
+          value: [ 'a', 'aa', 'ab', 'ba' ],
+        },
+      })
+
+      await wrapper.vm.$nextTick()
+    })
+
+    it('when showSelectedChildrenCount=false', async () => {
+      await setProps(wrapper, { showSelectedChildrenCount: false })
+
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'c').find('.vue-treeselect__count').exists()).toBeFalse()
+    })
+
+    it('when showSelectedChildrenCount not specified', () => {
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'c').find('.vue-treeselect__count').exists()).toBeFalse()
+    })
+
+    it('when showSelectedChildrenCount=true', async () => {
+      await setProps(wrapper, { showSelectedChildrenCount: true })
+
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(2/2 selected)')
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(1/2 selected)')
+      expect(findOptionByNodeId(wrapper, 'c').find('.vue-treeselect__count').text()).toEqual('(2)')
+    })
+
+    it('when showSelectedChildrenCount=true and showCount=true', async () => {
+      await setProps(wrapper, { showSelectedChildrenCount: true, showCount: true })
+
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(2/2 selected)')
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(1/2 selected)')
+      expect(findOptionByNodeId(wrapper, 'c').find('.vue-treeselect__count').text()).toEqual('(2)')
+    })
+
+    it('when showSelectedChildrenCount=true during search', async () => {
+      await setProps(wrapper, { showSelectedChildrenCount: true, searchable: true })
+
+      await typeSearchText(wrapper, 'a')
+
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').exists()).toBeFalse()
+      expect(findOptionByNodeId(wrapper, 'c').find('.vue-treeselect__count').exists()).toBeFalse()
+    })
+
+    it('when showSelectedChildrenCount=true and showCount=true during search', async () => {
+      await setProps(wrapper, { showSelectedChildrenCount: true, showCount: true, searchable: true })
+
+      await typeSearchText(wrapper, 'a')
+
+      expect(findOptionByNodeId(wrapper, 'a').find('.vue-treeselect__count').text()).toEqual('(2 found)')
+      expect(findOptionByNodeId(wrapper, 'b').find('.vue-treeselect__count').text()).toEqual('(1 found)')
+      expect(findOptionByNodeId(wrapper, 'c').find('.vue-treeselect__count').text()).toEqual('(1 found)')
     })
   })
 
@@ -3025,17 +3242,14 @@ describe('Props', () => {
       },
       attachToDocument: true,
     })
-    const { vm } = wrapper
 
-    vm.openMenu()
-    await vm.$nextTick()
+    await openMenu(wrapper.vm)
 
     const menuContainer = findMenuContainer(wrapper)
 
     expect(menuContainer.element.style.zIndex).toBe('1')
 
-    wrapper.setProps({ zIndex: 2 })
-    await vm.$nextTick()
+    await setProps(wrapper, { zIndex: 2 })
 
     expect(menuContainer.element.style.zIndex).toBe('2')
   })

--- a/test/unit/specs/shared.js
+++ b/test/unit/specs/shared.js
@@ -159,3 +159,13 @@ export function findChildrenOptionListByNodeId(wrapper, nodeId) {
     .find(optionWrapper => optionWrapper.vm.node.id === nodeId)
     .find('.vue-treeselect__list')
 }
+
+export async function setProps(wrapper, props) {
+  wrapper.setProps(props)
+  await wrapper.vm.$nextTick()
+}
+
+export async function openMenu(vm) {
+  vm.openMenu()
+  await vm.$nextTick()
+}


### PR DESCRIPTION
### Changes

Added NJ customizations onto riophae/vue-treeselect repo.

- Added `aria-label` prop to input.
- Added `exclusive` prop to force one branch expanded at a time.
- Added `showSelectedChildrenCount` prop to display count of selected items under a branch node
- Automatically collapse branch node if it's selected.

### Definitions

_Branch node means top level item with children_

### Testing:

- Clone repo, make sure you're on `updates` branch.
- `yarn install`
- `PORT=8081 yarn dev`
- Go to http://localhost:8081/#more-features
- Testing __showSelectedChildrenCount__:
   - Select `Show children count` and `Show selected children count` options, make sure `Multi-select` `Clearable` `Searchable` `Open on click` are selected as well.
   - When you open dropdown, you should see number of child elements `(3)` next to branch nodes.
   - When you expand one of branch nodes, you should still see `(3)` next to its label.
   - Select one of the children, let's say `A -> AA`
      - `A` will get partial selected [-], and `AA` should display check.
      - `A` label should still display `(3)`.
   - Collapse `A`. Label should now display `(1/3 selected)`
   - Expand `B`.
      -  Click `B` to select it and all child nodes.
      - `B` label should display `(3/3 selected)` and it should collapse automatically.
   - Click `C`. It should now also display `(3/3 selected)` next to it, and it should stay collapsed.
- Testing __showSelectedChildrenCount while searching__:
   - _Continuing off previous step with some items already selected_, type `A` into dropdown list to search for nodes containing `A`
      - You should NOT see how many items are selected, instead it should just display how many children are found under each branch node. 
- Testing __exclusive prop__:
   - Reload the page to reset demo dropdown, navigate to `More Features` again.
   - Select `Exclusive` option.
   - Expand `A` by clicking arrow next to the label. It should display its children.
   - Expand `B`. `A` should collapse, and `B` should be expanded now.
   - Expand `A`. `B` should collapse, and `A` should be expanded again.
- Testing __automatically collapse branch node if it's selected__:
   - Reload the page to reset demo dropdown, navigate to `More Features` again.
   - Expand `A` by clicking arrow next to the label. It should display its children.
   - Select `A` by either clicking checkbox or clicking on label.
      - `A` should collapse automatically.
   - Expand `B` by clicking arrow next to the label. It should display its children.
      - Select all 3 children of `B`.
      - `B` should collapse automatically once all children have been selected.