### PR TITLE
Merge fix-install branch (v0.5.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationaljournal/vue-treeselect",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A multi-select component with nested options support for Vue.js",
   "author": "Hasan Tuncay <htuncay@nationaljournal.com>",
   "license": "MIT",
@@ -13,7 +13,6 @@
   "unpkg": "dist/vue-treeselect.umd.min.js",
   "css": "dist/vue-treeselect.min.css",
   "files": [
-    "src",
     "dist"
   ],
   "scripts": {
@@ -31,7 +30,6 @@
     "lint:css": "stylelint '**/*.less'",
     "lint": "npm run lint:js && npm run lint:css",
     "verify-builds": "size-limit && node build/verify-builds.js",
-    "postinstall": "npm run finish",
     "finish": "npm run lint && npm test && npm run build-library && npm run verify-builds"
   },
   "pre-commit": "lint",


### PR DESCRIPTION
> Fix for slow package install, bumped version again

This is the version released as `0.5.2` on npm here: https://www.npmjs.com/package/@nationaljournal/vue-treeselect