### PR TITLE
Flat mode fixes

### DIFF
--- a/docs/components/NjTestingPlayground.vue
+++ b/docs/components/NjTestingPlayground.vue
@@ -1,0 +1,70 @@
+<template>
+  <div>
+    <div v-if="!multiple">
+      Value: <treeselect-value :value="value" />
+    </div>
+    <div>
+      <treeselect
+        v-model="value"
+        :multiple="multiple"
+        :disable-top-level-branch-nodes="disableTopLevelBranchNodes"
+        :flat="flat"
+        :ignore-flat-mode-fixing="ignoreFlatModeFixing"
+        :auto-select-descendants="autoSelectDescendants"
+        :limit="3"
+        :options="options"
+        :max-height="200"
+        />
+    </div>
+    <p style="display: flex; flex-direction: column; gap: 10px; margin-top: 30px;">
+      <button :style="{ color: !multiple ? 'blue' : 'gray' }" @click="setTest1">Test 1</button>
+      <button :style="{ color: !multiple ? 'gray' : 'blue' }" @click="setTest2">Test 2</button>
+    </p>
+    <p v-html="hint" />
+    <div v-if="multiple">
+      Extra Test Options:
+      <label><input type="checkbox" v-model="disableTopLevelBranchNodes"> Disable Top Level Nodes</label>
+    </div>
+  </div>
+</template>
+<script>
+  import { generateOptions } from './utils'
+
+  export default {
+    data: () => ({
+      multiple: false,
+      disableTopLevelBranchNodes: true,
+      flat: false,
+      ignoreFlatModeFixing: false,
+      autoSelectDescendants: false,
+      value: null,
+      options: generateOptions(3, 2),
+      hint: '',
+      hint1: 'You can select branch nodes: <b>AA, AB, BA,</b> and <b>BB</b>. You cannot select top level branch nodes: <b>A, B</b>. The value below will change when you select a branch node and not a top level node',
+      hint2: 'Selecting a branch node will auto select its descendants, but de-selecting will not auto deselect anything. Thereby keeping the branch nodes selected when desired.',
+    }),
+    beforeMount() {
+      this.hint = this.hint1
+    },
+    methods: {
+      setTest1() {
+        this.disableTopLevelBranchNodes = true
+        this.multiple = false
+        this.ignoreFlatModeFixing = false
+        this.autoSelectDescendants = false
+        this.hint = this.hint1
+        this.value = null
+        this.flat = false
+      },
+      setTest2() {
+        this.disableTopLevelBranchNodes = false
+        this.multiple = true
+        this.flat = true
+        this.ignoreFlatModeFixing = true
+        this.autoSelectDescendants = true
+        this.hint = this.hint2
+        this.value = []
+      },
+    },
+  }
+  </script>

--- a/docs/partials/dev.pug
+++ b/docs/partials/dev.pug
@@ -20,3 +20,18 @@ if NODE_ENV !== 'production'
 
   +subsection('Long Label Test')
     +component('LongLabelTest')
+
+  +subsection('Nj Testing Playground')
+    :markdown-it
+      This is a playground for testing changes that were made in order to better support the nj-cms repository.
+      Please note that this will not test the specific logic around the url shortening functionality as that is
+      specific to the nj-cms repository.
+      The current testing scenarios are:
+      - Being able to select non-top level branch nodes as routeable values (**Test 1**)
+      - Non-top level branch nodes are a value on their own for searches. (**Test 2**)
+          - The behvaior should be that selecting a branch node selects all of its children but de-selecting any or all 
+            of the children will not deselect the branch node. For example, selecting "AB" will select all of its descendants
+            but de-selecting any or all descendants of "AB" will not deselect "AB".
+
+      You can select these scenarios below to put the component in the desired state and then manually test the component.
+    +demo('NjTestingPlayground')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationaljournal/vue-treeselect",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A multi-select component with nested options support for Vue.js",
   "author": "Hasan Tuncay <htuncay@nationaljournal.com>",
   "license": "MIT",

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -341,6 +341,14 @@ export default {
     },
 
     /**
+     * Whether to ignore the flat mode fixing of selected nodes.
+     */
+    ignoreFlatModeFixing: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
      * Will be passed with all events as the last param.
      * Useful for identifying events origin.
     */
@@ -1067,7 +1075,7 @@ export default {
       let nextSelectedNodeIds = []
 
       // istanbul ignore else
-      if (this.single || this.flat || this.disableBranchNodes || this.valueConsistsOf === ALL) {
+      if (this.single || (this.flat && !this.ignoreFlatModeFixing) || this.disableBranchNodes || this.valueConsistsOf === ALL) {
         nextSelectedNodeIds = nodeIdListOfPrevValue
       } else if (this.valueConsistsOf === BRANCH_PRIORITY) {
         nodeIdListOfPrevValue.forEach(nodeId => {
@@ -1571,6 +1579,14 @@ export default {
               if (!this.isSelected(ancestorNode)) {
                 this.$set(checkedStateMap, ancestorNode.id, INDETERMINATE)
               }
+            })
+          } else if (this.flat && !this.disableBranchNodes) {
+            selectedNode.ancestors.forEach(ancestorNode => {
+              this.$set(
+                ancestorNode.count,
+                ALL_DESCENDANTS_SELECTED,
+                ancestorNode.count.ALL_DESCENDANTS_SELECTED + 1,
+              )
             })
           }
         })


### PR DESCRIPTION
This PR addresses some changes to how flat mode fixes can be optionally ignored, keeping original behavior intact while allowing custom behavior to work in the case of ticket https://github.com/NationalJournal/nj-cms/issues/7719

# Testing

1. GIt clone this repo onto your machine and then checkout this branch (since this isn't part of the nj-cms repo it will be a completely new setup).
2. Run `npm run build-docs`
3. Run `npm run dev`
    1. it will auto open the dev site in a new browser window
4. Scroll to the Nj Testing Playground and follow the instructions there for tests 1 and 2. If everything checks out there we are good to go.